### PR TITLE
Fix projects link and remove unused links

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,7 +57,7 @@ Experience collaborating across **biomechanics, evolutionary biology, and AI** t
 ## **🚀 Featured Work**  
 **Explore my projects, research, and open-source contributions:**  
 <div style="text-align: center; margin-top: 10px;">
-    <a href="/projects.md" style="
+    <a href="{{ "/projects/" | relative_url }}" style="
         background-color: #007BFF;
         color: white;
         padding: 12px 20px;
@@ -74,8 +74,7 @@ Experience collaborating across **biomechanics, evolutionary biology, and AI** t
 ---
 
 ## **📩 Get in Touch**
-📧 [oothomas07@gmail.com](mailto:oothomas07@gmail.com)  
-🔗 Connect on **[LinkedIn](https://www.linkedin.com/in/oshane-o-thomas)**  
-📂 Explore my **[Publications](publications/)** and **[Tools](tools/)**  
+📧 [oothomas07@gmail.com](mailto:oothomas07@gmail.com)
+🔗 Connect on **[LinkedIn](https://www.linkedin.com/in/oshane-o-thomas)**
 
 ---


### PR DESCRIPTION
## Summary
- Use Jekyll `relative_url` helper for the Projects button so URLs resolve correctly.
- Remove links to non-existent Publications and Tools pages from the contact section.

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll bundler` *(fails: 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a4c03a7acc8327b158e18ee7e62a57