### PR TITLE
Style navigation bar links as buttons and add Home link

### DIFF
--- a/cv.md
+++ b/cv.md
@@ -4,12 +4,24 @@ title: "Curriculum Vitae"
 permalink: /cv/
 ---
 
+<style>
+.nav-button {
+  padding: 10px 15px;
+  background-color: #007bff;
+  color: #fff;
+  border-radius: 5px;
+  text-decoration: none;
+  font-size: 18px;
+}
+</style>
+
 <nav style="display: flex; justify-content: center; gap: 15px; margin: 20px 0; background-color: #f5f5f5; padding: 10px; border-radius: 8px;">
-  <a href="/#expertise-skills">Expertise & Skills</a>
-  <a href="/#career-highlights">Career Highlights</a>
-  <a href="/#projects">Projects</a>
-  <a href="/cv/">CV</a>
-  <a href="/#get-in-touch">Get in Touch</a>
+  <a href="/" class="nav-button">Home</a>
+  <a href="/#expertise-skills" class="nav-button">Expertise & Skills</a>
+  <a href="/#career-highlights" class="nav-button">Career Highlights</a>
+  <a href="/#projects" class="nav-button">Projects</a>
+  <a href="/cv/" class="nav-button">CV</a>
+  <a href="/#get-in-touch" class="nav-button">Get in Touch</a>
 </nav>
 
 # Oshane O. Thomas, PhD

--- a/index.md
+++ b/index.md
@@ -3,12 +3,24 @@ layout: default
 title: "Home"
 ---
 
+<style>
+.nav-button {
+  padding: 10px 15px;
+  background-color: #007bff;
+  color: #fff;
+  border-radius: 5px;
+  text-decoration: none;
+  font-size: 18px;
+}
+</style>
+
 <nav style="display: flex; justify-content: center; gap: 15px; margin: 20px 0; background-color: #f5f5f5; padding: 10px; border-radius: 8px;">
-  <a href="/#expertise-skills">Expertise & Skills</a>
-  <a href="/#career-highlights">Career Highlights</a>
-  <a href="/#projects">Projects</a>
-  <a href="/cv/">CV</a>
-  <a href="/#get-in-touch">Get in Touch</a>
+  <a href="/" class="nav-button">Home</a>
+  <a href="/#expertise-skills" class="nav-button">Expertise & Skills</a>
+  <a href="/#career-highlights" class="nav-button">Career Highlights</a>
+  <a href="/#projects" class="nav-button">Projects</a>
+  <a href="/cv/" class="nav-button">CV</a>
+  <a href="/#get-in-touch" class="nav-button">Get in Touch</a>
 </nav>
 
 # **Oshane O. Thomas, PhD**


### PR DESCRIPTION
## Summary
- Turn navigation links into button-style elements with larger text for improved visual interest
- Add a first "Home" navigation link to jump back to the top of the site
- Apply the updated navigation bar styling to both the home page and the CV page

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cacc900c832799f5f770afc9a89f