### PR TITLE
Improve skills and tech stack card contrast

### DIFF
--- a/assets/css/skills.css
+++ b/assets/css/skills.css
@@ -13,8 +13,9 @@
 }
 
 .skill-card {
-  background: var(--card-bg, #f9f9f9);
-  border: 1px solid #e0e0e0;
+  background: #121417;
+  color: #e6e6e6;
+  border: 1px solid #2a2c30;
   border-radius: 8px;
   padding: 1rem;
   transition: transform 0.3s ease, box-shadow 0.3s ease;
@@ -31,6 +32,7 @@
 .skill-card h3 {
   margin-top: 0;
   margin-bottom: 0.5rem;
+  color: #ffffff;
 }
 .skill-card ul {
   margin: 0;
@@ -46,6 +48,7 @@
 .tech-stack h3 {
   font-size: 1.1em;
   margin-bottom: 0.5rem;
+  color: #ffffff;
 }
 .tech-list {
   list-style: none;
@@ -55,8 +58,9 @@
   gap: 0.75rem;
 }
 .tech-list li {
-  background: var(--card-bg, #f9f9f9);
-  border: 1px solid #e0e0e0;
+  background: #121417;
+  color: #e6e6e6;
+  border: 1px solid #2a2c30;
   border-radius: 5px;
   padding: 0.3rem 0.6rem;
   font-size: 0.9em;
@@ -70,7 +74,7 @@
 
 @media (prefers-color-scheme: dark) {
   .focus-box { background: rgba(255,255,255,0.07); }
-  .skill-card { background: #1e1e1e; border: 1px solid #333; }
+  .skill-card { background: #121417; border: 1px solid #2a2c30; }
   .skill-card .card-icon { color: var(--accent-color, #4aa8ff); }
-  .tech-list li { background: #1e1e1e; border: 1px solid #333; }
+  .tech-list li { background: #121417; border: 1px solid #2a2c30; }
 }


### PR DESCRIPTION
## Summary
- darken skill card backgrounds to #121417 and lighten text for readability
- lighten text and backgrounds for tech stack items to match skill cards

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5dc335bfc832783ec679ab3c5f195