### PR TITLE
Ensure skill card headings use accent color

### DIFF
--- a/assets/css/skills.css
+++ b/assets/css/skills.css
@@ -32,7 +32,7 @@
 .skill-card h3 {
   margin-top: 0;
   margin-bottom: 0.5rem;
-  color: #25589a;
+  color: #25589a !important;
 }
 .skill-card ul {
   margin: 0;


### PR DESCRIPTION
## Summary
- enforce accent color on skill card headings

## Testing
- `jekyll build` *(fails: command not found)*
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e16c5f348327b0c54448297d7950