### PR TITLE
Move tech stack above skills and set heading color

### DIFF
--- a/assets/css/skills.css
+++ b/assets/css/skills.css
@@ -51,7 +51,7 @@
 .tech-stack h3 {
   font-size: 1.1em;
   margin-bottom: 0.5rem;
-  color: #ffffff;
+  color: #000000;
 }
 .tech-list {
   list-style: none;

--- a/index.md
+++ b/index.md
@@ -67,6 +67,21 @@ title: "Home"
   <p><strong>Throughline:</strong> Ship interpretable, reproducible systems for segmentation, classification, detection, registration, and landmarking on volumetric data.</p>
 </div>
 
+<!-- Tech Stack as an icon list -->
+<div class="tech-stack">
+  <h3>Tech stack at a glance:</h3>
+  <ul class="tech-list">
+    <li><i class="devicon-python-plain colored"></i> Python</li>
+    <li><i class="devicon-pytorch-original colored"></i> PyTorch</li>
+    <li><i class="devicon-tensorflow-original colored"></i> TensorFlow/Keras</li>
+    <li><i class="devicon-docker-plain colored"></i> Docker</li>
+    <li><i class="devicon-amazonwebservices-original colored"></i> AWS</li>
+    <li><i class="devicon-googlecloud-plain colored"></i> GCP</li>
+    <li><i class="devicon-microsoftsqlserver-plain colored"></i> SQL</li>
+    <li><i class="fa-solid fa-cube"></i> NIfTI/DICOM</li>
+  </ul>
+</div>
+
 <!-- Responsive grid of skill cards -->
 <div class="skills-grid">
   <!-- Card 1: Modalities & Data Ops -->
@@ -128,21 +143,6 @@ title: "Home"
       <li>Bayesian &amp; classical inference; variational methods; predictive modeling; statistical shape analysis; evaluation beyond accuracy (AUPRC, calibration, uncertainty).</li>
     </ul>
   </div>
-</div>
-
-<!-- Tech Stack as an icon list -->
-<div class="tech-stack">
-  <h3>Tech stack at a glance:</h3>
-  <ul class="tech-list">
-    <li><i class="devicon-python-plain colored"></i> Python</li>
-    <li><i class="devicon-pytorch-original colored"></i> PyTorch</li>
-    <li><i class="devicon-tensorflow-original colored"></i> TensorFlow/Keras</li>
-    <li><i class="devicon-docker-plain colored"></i> Docker</li>
-    <li><i class="devicon-amazonwebservices-original colored"></i> AWS</li>
-    <li><i class="devicon-googlecloud-plain colored"></i> GCP</li>
-    <li><i class="devicon-microsoftsqlserver-plain colored"></i> SQL</li>
-    <li><i class="fa-solid fa-cube"></i> NIfTI/DICOM</li>
-  </ul>
 </div>
 
 <!-- no <hr> here either -->


### PR DESCRIPTION
## Summary
- Repositioned the "Tech stack at a glance" section above the skills cards for improved prominence.
- Styled the tech stack heading with a black font color.

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e3e17db88327a34efe5971937431