### PR TITLE
Enlarge site title and description

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -2,3 +2,14 @@
 ---
 @import "{{ site.theme }}";
 .wrapper { max-width: 1200px; width: 90%; }
+
+/* Enlarge site title and description */
+.project-name,
+.site-title {
+  font-size: 300%;
+}
+
+.project-tagline,
+.site-description {
+  font-size: 300%;
+}


### PR DESCRIPTION
## Summary
- triple the displayed size of site title and description via CSS selectors

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a652eb84588327a6ce4809f38227f9