### PR TITLE
Enlarge site header text

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -4,12 +4,10 @@
 .wrapper { max-width: 1200px; width: 90%; }
 
 /* Enlarge site title and description */
-.project-name,
-.site-title {
+header h1 {
   font-size: 300%;
 }
 
-.project-tagline,
-.site-description {
+header p:not(.view) {
   font-size: 300%;
 }


### PR DESCRIPTION
## Summary
- increase site title and description font size by 300%

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a65445ebe88327945e30886bf94d65