### PR TITLE
Expand header description width

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -10,4 +10,5 @@ header h1 {
 
 header p:not(.view) {
   font-size: 150%;
+  width: 100%;
 }


### PR DESCRIPTION
## Summary
- widen header description container to 100% so tagline stays on one line after font size increase

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6564923388327a0ec91e3ae83c758