### PR TITLE
Reorder navigation and project section placement

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -24,8 +24,8 @@
 
 <nav style="display:flex;flex-wrap:wrap;justify-content:center;gap:15px;margin:20px 0;background:#f5f5f5;padding:10px;border-radius:8px;">
   <a href="/" class="nav-button">Home</a>
-  <a href="/about/" class="nav-button">About Me</a>
   <a href="/#projects" class="nav-button">Projects</a>
   <a href="/#skills-and-expertise" class="nav-button">Skills and Expertise</a>
-  <a href="/#cv" class="nav-button">CV</a>
+  <a href="/#cv" class="nav-button">CV.</a>
+  <a href="/about/" class="nav-button">About Me</a>
 </nav>

--- a/index.md
+++ b/index.md
@@ -25,6 +25,13 @@ title: "Home"
 
 <!-- no <hr> here to avoid the white line above Projects -->
 
+<h2 id="projects">🚀 Featured Work</h2>
+
+<!-- Standard include (no full-bleed wrapper) -->
+{% include projects.html %}
+
+<!-- no <hr> here either -->
+
 <h2 id="skills-and-expertise">🛠️ Skills and Expertise</h2>
 <!-- Introductory Focus/Throughline Highlight -->
 <div class="focus-box">
@@ -114,13 +121,6 @@ title: "Home"
     </ul>
   </div>
 </div>
-
-<!-- no <hr> here either -->
-
-<h2 id="projects">🚀 Featured Work</h2>
-
-<!-- Standard include (no full-bleed wrapper) -->
-{% include projects.html %}
 
 <hr>
 


### PR DESCRIPTION
## Summary
- Reordered navigation buttons: Home, Projects, Skills and Expertise, CV., About Me
- Moved Projects section above Skills and Expertise
- Kept CV section last after skills

## Testing
- `jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68a7b2f177d08327a4bd5d05ff25477c