### PR TITLE
style: refresh skills card palette

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -4,12 +4,12 @@
 
 /* Palette */
 :root {
-  --accent: #2a63a4;
-  --accent-hover: #1d4f8c;
+  --accent: #2563EB;
+  --accent-hover: #1D4ED8;
   --card-bg: #ffffff;
-  --card-border: #e6e6e6;
-  --text: #222;
-  --muted: #666;
+  --card-border: #E5E7EB;
+  --text: #1E293B;
+  --muted: #475569;
   --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
   --shadow-md: 0 4px 10px rgba(0,0,0,0.12);
 
@@ -138,6 +138,21 @@ a:focus .thumb .thumb-caption { opacity: 1; }
 .btn-sm:hover,
 .btn-sm:focus { background: var(--accent-hover); transform: translateY(-1px); box-shadow: 0 3px 6px rgba(0,0,0,0.15); }
 .btn-sm:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.btn-secondary {
+  display: inline-block;
+  padding: 6px 10px;
+  background: #E2E8F0;
+  color: #1E293B !important;
+  border-radius: 6px;
+  text-decoration: none;
+  font-size: 0.92rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  transition: transform .15s ease, box-shadow .15s ease, background .2s ease;
+}
+.btn-secondary:hover,
+.btn-secondary:focus { background: #CBD5E1; transform: translateY(-1px); box-shadow: 0 3px 6px rgba(0,0,0,0.15); }
+.btn-secondary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 .project-citation {
   margin: 6px 0 0 0;

--- a/assets/css/skills.css
+++ b/assets/css/skills.css
@@ -13,26 +13,27 @@
 }
 
 .skill-card {
-  background: #121417;
-  color: #e2e2e2;
-  border: 1px solid #2a2c30;
+  background: #F8FAFC;
+  color: #1E293B;
+  border: 1px solid #E5E7EB;
   border-radius: 8px;
   padding: 1rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
   transition: transform 0.3s ease, box-shadow 0.3s ease;
 }
 .skill-card:hover {
   transform: translateY(-4px);
-  box-shadow: 0 4px 15px rgba(0,0,0,0.1);
+  box-shadow: 0 4px 6px rgba(0,0,0,0.1);
 }
 .skill-card .card-icon {
   font-size: 1.5rem;
   margin-bottom: 0.5rem;
-  color: var(--accent-color, #2a63a4);
+  color: #2563EB;
 }
 .skill-card h3 {
   margin-top: 0;
   margin-bottom: 0.5rem;
-  color: #25589a !important;
+  color: #2563EB;
 }
 .skill-card ul {
   margin: 0;
@@ -40,9 +41,10 @@
 }
 .skill-card li {
   margin-bottom: 0.5em;
+  color: #475569;
 }
 .skill-card strong {
-  color: #419eff;
+  color: #1E293B;
 }
 
 .tech-stack {
@@ -51,7 +53,7 @@
 .tech-stack h3 {
   font-size: 1.1em;
   margin-bottom: 0.5rem;
-  color: #000000;
+  color: #1E293B;
 }
 .tech-list {
   list-style: none;
@@ -61,14 +63,18 @@
   gap: 0.75rem;
 }
 .tech-list li {
-  background: #121417;
-  color: #e6e6e6;
-  border: 1px solid #2a2c30;
+  background: #E2E8F0;
+  color: #1E293B;
+  border: 1px solid #CBD5E1;
   border-radius: 5px;
   padding: 0.3rem 0.6rem;
   font-size: 0.9em;
   display: flex;
   align-items: center;
+  transition: background 0.2s ease;
+}
+.tech-list li:hover {
+  background: #CBD5E1;
 }
 .tech-list i {
   font-size: 1.2em;
@@ -77,7 +83,19 @@
 
 @media (prefers-color-scheme: dark) {
   .focus-box { background: rgba(255,255,255,0.07); }
-  .skill-card { background: #121417; border: 1px solid #2a2c30; }
-  .skill-card .card-icon { color: var(--accent-color, #4aa8ff); }
-  .tech-list li { background: #121417; border: 1px solid #2a2c30; }
+  .skill-card {
+    background: #121417;
+    color: #e2e2e2;
+    border: 1px solid #2a2c30;
+    box-shadow: none;
+  }
+  .skill-card li { color: #a8b0ba; }
+  .skill-card strong { color: #ffffff; }
+  .skill-card .card-icon { color: #4aa8ff; }
+  .tech-list li {
+    background: #121417;
+    color: #e6e6e6;
+    border: 1px solid #2a2c30;
+  }
+  .tech-list li:hover { background: #1e2329; }
 }


### PR DESCRIPTION
## Summary
- restyle skills cards with light backgrounds and readable dark text
- update project button colors and introduce neutral secondary button style

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b62b10208327ab32c84b8290b2fc