### PR TITLE
fix: update skills card colors

### DIFF
--- a/assets/css/skills.css
+++ b/assets/css/skills.css
@@ -41,7 +41,7 @@
 }
 .skill-card li {
   margin-bottom: 0.5em;
-  color: #475569;
+  color: #1E293B;
 }
 .skill-card strong {
   color: #1E293B;
@@ -83,15 +83,6 @@
 
 @media (prefers-color-scheme: dark) {
   .focus-box { background: rgba(255,255,255,0.07); }
-  .skill-card {
-    background: #121417;
-    color: #e2e2e2;
-    border: 1px solid #2a2c30;
-    box-shadow: none;
-  }
-  .skill-card li { color: #a8b0ba; }
-  .skill-card strong { color: #ffffff; }
-  .skill-card .card-icon { color: #4aa8ff; }
   .tech-list li {
     background: #121417;
     color: #e6e6e6;


### PR DESCRIPTION
## Summary
- use requested #F8FAFC background and #1E293B text for skills cards
- remove dark-mode overrides so new colors persist

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b829ed0c8327b880890cdbb450dd