### PR TITLE
style: update project card colors

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -6,10 +6,11 @@
 :root {
   --accent: #2563EB;
   --accent-hover: #1D4ED8;
-  --card-bg: #ffffff;
+  --card-bg: #F8FAFC;
   --card-border: #E5E7EB;
   --text: #1E293B;
   --muted: #475569;
+  --citation: #334155;
   --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
   --shadow-md: 0 4px 10px rgba(0,0,0,0.12);
 
@@ -130,9 +131,10 @@ a:focus .thumb .thumb-caption { opacity: 1; }
   background: var(--accent);
   color: #fff !important;
   border-radius: 6px;
+  border: 1px solid var(--card-border);
   text-decoration: none;
   font-size: 0.92rem;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
   transition: transform .15s ease, box-shadow .15s ease, background .2s ease;
 }
 .btn-sm:hover,
@@ -145,9 +147,10 @@ a:focus .thumb .thumb-caption { opacity: 1; }
   background: #E2E8F0;
   color: #1E293B !important;
   border-radius: 6px;
+  border: 1px solid var(--card-border);
   text-decoration: none;
   font-size: 0.92rem;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
   transition: transform .15s ease, box-shadow .15s ease, background .2s ease;
 }
 .btn-secondary:hover,
@@ -157,7 +160,7 @@ a:focus .thumb .thumb-caption { opacity: 1; }
 .project-citation {
   margin: 6px 0 0 0;
   font-size: 0.92rem;
-  color: var(--muted);
+  color: var(--citation);
   line-height: 1.35;
 }
 
@@ -181,6 +184,7 @@ a:focus .thumb .thumb-caption { opacity: 1; }
     --card-border: #29313a;
     --text: #e6e6e6;
     --muted: #a8b0ba;
+    --citation: #a8b0ba;
     --shadow-sm: 0 1px 2px rgba(0,0,0,0.6);
     --shadow-md: 0 6px 16px rgba(0,0,0,0.7);
   }


### PR DESCRIPTION
## Summary
- adjust project card background to light slate #F8FAFC and refine publication text color
- style buttons with slate borders and softer shadows

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7bada27d48327bee8ae49e434d362