### PR TITLE
Ensure project card styles use slate palette and button accents

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -9,8 +9,8 @@
   --card-bg: #F8FAFC;
   --card-border: #E5E7EB;
   --text: #1E293B;
-  --muted: #475569;
-  --citation: #334155;
+  --muted: #64748B;
+  --citation: #475569;
   --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
   --shadow-md: 0 4px 10px rgba(0,0,0,0.12);
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,7 +1,6 @@
 ---
 ---
 @import "{{ site.theme }}";
-@import "projects.css";
 .wrapper { max-width: 1200px; width: 90%; }
 
 /* Enlarge site title and description */

--- a/index.md
+++ b/index.md
@@ -7,6 +7,9 @@ title: "Home"
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css">
 <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
 
+<!-- Project gallery styles -->
+<link rel="stylesheet" href="{{ '/assets/css/projects.css' | relative_url }}">
+
 <!-- Icon libraries and skills styling -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devicons/devicon@v2.15.1/devicon.min.css">


### PR DESCRIPTION
## Summary
- Re-link the project gallery stylesheet so custom card and button styles load
- Drop unused import from the main stylesheet
- Tune card palette variables for light slate background, dark slate text, and softer publication color

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c13a933c8327a24dcef815badb52