### PR TITLE
Ensure project card background matches requested color

### DIFF
--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -180,13 +180,14 @@ a:focus .thumb .thumb-caption { opacity: 1; }
 /* Gentle dark mode */
 @media (prefers-color-scheme: dark) {
   :root {
-    --card-bg: #111418;
-    --card-border: #29313a;
-    --text: #e6e6e6;
-    --muted: #a8b0ba;
-    --citation: #94A3B8;
-    --shadow-sm: 0 1px 2px rgba(0,0,0,0.6);
-    --shadow-md: 0 6px 16px rgba(0,0,0,0.7);
+    /* Mirror light theme variables so card stays #F8FAFC */
+    --card-bg: #F8FAFC;
+    --card-border: #E5E7EB;
+    --text: #1E293B;
+    --muted: #64748B;
+    --citation: #475569;
+    --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+    --shadow-md: 0 4px 10px rgba(0,0,0,0.12);
   }
-  .thumb { background: #0e1216; }
+  .thumb { background: #f3f6fa; }
 }


### PR DESCRIPTION
## Summary
- Mirror light theme variables in dark mode so project cards use the `#F8FAFC` background as requested
- Adjust related color variables and thumbnail background to keep appearance consistent

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ca9619d48327b34c91bef0b1da94