### PR TITLE
Add publications section and navigation link

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -24,6 +24,7 @@
 
 <nav style="display:flex;flex-wrap:wrap;justify-content:center;gap:15px;margin:20px 0;background:#f5f5f5;padding:10px;border-radius:8px;">
   <a href="/" class="nav-button">Home</a>
+  <a href="/#publications" class="nav-button">Publications</a>
   <a href="/#projects" class="nav-button">Projects</a>
   <a href="/#skills-and-expertise" class="nav-button">Skills and Expertise</a>
   <a href="/#cv" class="nav-button">CV.</a>

--- a/assets/css/publications.css
+++ b/assets/css/publications.css
@@ -1,0 +1,25 @@
+/* Publications section styles */
+.pub-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 2rem 0;
+}
+
+.publication {
+  background: var(--card-bg, #F8FAFC);
+  border-left: 4px solid var(--accent, #2563EB);
+  padding: 1rem;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.publication h4 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1rem;
+}
+
+.publication p {
+  margin: 0;
+  line-height: 1.4;
+}

--- a/index.md
+++ b/index.md
@@ -14,6 +14,7 @@ title: "Home"
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devicons/devicon@v2.15.1/devicon.min.css">
 <link rel="stylesheet" href="{{ '/assets/css/skills.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/css/publications.css' | relative_url }}">
 
 {% include nav.html %}
 
@@ -22,6 +23,27 @@ title: "Home"
      alt="Skills banner"
      width="1200" height="314"
      style="display:block; margin:0 auto; width:100%; max-width:1200px; height:auto;">
+
+<h2 id="publications">📚 Publications</h2>
+<h3>Peer-Reviewed Publications</h3>
+<div class="pub-list">
+  <div class="publication">
+    <h4>Trustworthy detection of exencephaly in high-throughput micro-CT embryo screens with focal-loss transformers</h4>
+    <p>Thomas, O. O., Roston, R., Shen, H., &amp; Maga, A. M. (2025). <em>BioRxiv</em> (In Review: PLOS Computational Biology). <a href="https://doi.org/10.1101/2025.08.12.669840" target="_blank">https://doi.org/10.1101/2025.08.12.669840</a></p>
+  </div>
+  <div class="publication">
+    <h4>SlicerMorph photogrammetry: An open-source photogrammetry workflow for reconstructing 3D models</h4>
+    <p>Thomas, O. O., Zhang, C., &amp; Maga, A. M. (2025). <em>Biology Open</em>, 14, bio062126. In Press. <a href="https://doi.org/10.1242/bio.062126" target="_blank">https://doi.org/10.1242/bio.062126</a></p>
+  </div>
+  <div class="publication">
+    <h4>Leveraging descriptor learning and functional map-based shape matching for automated anatomical landmarking in mouse mandibles</h4>
+    <p>Thomas, O. O., &amp; Maga, A. M. (2025). <em>Journal of Anatomy</em>, 00, 1–17. <a href="https://doi.org/10.1111/joa.14196" target="_blank">https://doi.org/10.1111/joa.14196</a></p>
+  </div>
+  <div class="publication">
+    <h4>Automated morphological phenotyping using learned shape descriptors and functional maps: A novel approach to geometric morphometrics</h4>
+    <p>Thomas, O. O., Shen, H., Raaum, R. L., Harcourt-Smith, W. H. E., Polk, J. D., &amp; Hasegawa-Johnson, M. (2023). <em>PLOS Computational Biology</em>, 19(1), e1009061.</p>
+  </div>
+</div>
 
 <!-- no <hr> here to avoid the white line above Projects -->
 


### PR DESCRIPTION
## Summary
- Add a styled Publications section above Featured Work
- Include Publications link in top navigation
- Create CSS for publication cards

## Testing
- `jekyll build` *(fails: `cannot load such file -- jekyll-remote-theme`)*

------
https://chatgpt.com/codex/tasks/task_e_68a88f3c4b908327a78804d61f68996e