### PR TITLE
Remove project references from project cards

### DIFF
--- a/_includes/projects.html
+++ b/_includes/projects.html
@@ -27,8 +27,6 @@
         {% if proj.repo_url  %}<a class="btn-sm" href="{{ proj.repo_url  }}" target="_blank" rel="noopener">GitHub</a>{% endif %}
         {% if proj.demo_url  %}<a class="btn-sm" href="{{ proj.demo_url  }}" target="_blank" rel="noopener">Demo</a>{% endif %}
       </div>
-
-      {% if proj.publication %}<p class="project-citation">{{ proj.publication }}</p>{% endif %}
     </div>
   </article>
 {% endfor %}

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -10,7 +10,6 @@
   --card-border: #E5E7EB;
   --text: #1E293B;
   --muted: #64748B;
-  --citation: #475569;
   --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
   --shadow-md: 0 4px 10px rgba(0,0,0,0.12);
 
@@ -156,14 +155,6 @@ a:focus .thumb .thumb-caption { opacity: 1; }
 .btn-secondary:hover,
 .btn-secondary:focus { background: #CBD5E1; transform: translateY(-1px); box-shadow: 0 3px 6px rgba(0,0,0,0.15); }
 .btn-secondary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-
-.project-citation {
-  margin: 6px 0 0 0;
-  font-size: 0.92rem;
-  color: var(--citation);
-  line-height: 1.35;
-}
-
 /* Responsiveness */
 @media (max-width: 760px) {
   .project-thumbs { max-width: none; grid-template-columns: 1fr; }
@@ -185,7 +176,6 @@ a:focus .thumb .thumb-caption { opacity: 1; }
     --card-border: #E5E7EB;
     --text: #1E293B;
     --muted: #64748B;
-    --citation: #475569;
     --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
     --shadow-md: 0 4px 10px rgba(0,0,0,0.12);
   }


### PR DESCRIPTION
## Summary
- remove citation text from project cards so only buttons remain
- drop unused citation styling

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll --no-document` *(fails: Building native extensions. This could take a while...)*

------
https://chatgpt.com/codex/tasks/task_e_68a893edb5248327ba5f39b1b140cd58