### PR TITLE
Add recruiter-focused experience section with navigation link

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -24,6 +24,7 @@
 
 <nav style="display:flex;flex-wrap:wrap;justify-content:center;gap:15px;margin:20px 0;background:#f5f5f5;padding:10px;border-radius:8px;">
   <a href="/" class="nav-button">Home</a>
+  <a href="/#experience" class="nav-button">Experience</a>
   <a href="/#publications" class="nav-button">Publications</a>
   <a href="/#projects" class="nav-button">Projects</a>
   <a href="/#skills-and-expertise" class="nav-button">Skills and Expertise</a>

--- a/assets/css/experience.css
+++ b/assets/css/experience.css
@@ -1,0 +1,33 @@
+/* Experience section styles */
+.experience-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin: 2rem 0;
+}
+
+.experience-item {
+  background: var(--card-bg, #F8FAFC);
+  border-left: 4px solid var(--accent, #2563EB);
+  padding: 1rem 1.25rem;
+  border-radius: 6px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+}
+
+.experience-item h3 {
+  margin-top: 0;
+  margin-bottom: 0.25rem;
+  font-size: 1.1rem;
+}
+
+.experience-item .meta {
+  font-size: 0.95rem;
+  color: #555;
+  margin-bottom: 0.75rem;
+}
+
+.experience-item ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  line-height: 1.4;
+}

--- a/index.md
+++ b/index.md
@@ -15,6 +15,7 @@ title: "Home"
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devicons/devicon@v2.15.1/devicon.min.css">
 <link rel="stylesheet" href="{{ '/assets/css/skills.css' | relative_url }}">
 <link rel="stylesheet" href="{{ '/assets/css/publications.css' | relative_url }}">
+<link rel="stylesheet" href="{{ '/assets/css/experience.css' | relative_url }}">
 
 {% include nav.html %}
 
@@ -42,6 +43,43 @@ title: "Home"
   <div class="publication">
     <h4>Automated morphological phenotyping using learned shape descriptors and functional maps: A novel approach to geometric morphometrics</h4>
     <p>Thomas, O. O., Shen, H., Raaum, R. L., Harcourt-Smith, W. H. E., Polk, J. D., &amp; Hasegawa-Johnson, M. (2023). <em>PLOS Computational Biology</em>, 19(1), e1009061. <a href="https://doi.org/10.1371/journal.pcbi.1009061" target="_blank">https://doi.org/10.1371/journal.pcbi.1009061</a></p>
+  </div>
+</div>
+
+<!-- Experience section -->
+<h2 id="experience">💼 Experience</h2>
+<div class="experience-list">
+  <div class="experience-item">
+    <h3>Postdoctoral Fellow</h3>
+    <p class="meta">Seattle Children’s Research Institute &amp; The Imageomics Institute, Seattle, WA (09/2023–Present)</p>
+    <ul>
+      <li>Built end-to-end pipelines for micro-CT embryo analysis (NIfTI), covering segmentation, classification, detection, and registration; packaged with Docker/MLflow for reproducibility and cloud training.</li>
+      <li>Designed and published a 3D Slicer extension integrating SAM-based segmentation with WebODM photogrammetry, cutting 3D reconstruction error by ~15% on fragile specimens; enabled volume-to-mesh workflows for downstream analysis.</li>
+      <li>Developed focal-loss Vision Transformer models for neural tube defect (exencephaly) detection under extreme class imbalance; improved AUPRC and stabilized XAI saliency.</li>
+      <li>Automated functional-map-based landmarking for 3D morphology, boosting reproducibility and throughput; integrated experiment tracking (MLflow) and artifact versioning.</li>
+      <li>Led monthly training on medical imaging ML (3D CNNs, ViTs, SSL, Photogrammetry), supporting cross-functional teams.</li>
+    </ul>
+  </div>
+  <div class="experience-item">
+    <h3>Research Assistant</h3>
+    <p class="meta">Speech Technology Group, Coordinated Science Lab, Grainger College of Engineering, UIUC (09/2021–08/2023)</p>
+    <ul>
+      <li>Adapted Transformer architectures with XAI for high-dimensional gait/kinematics; delivered interpretable, production-grade models and validation reports.</li>
+    </ul>
+  </div>
+  <div class="experience-item">
+    <h3>Research Assistant</h3>
+    <p class="meta">Evolutionary Biomechanics Lab, Department of Anthropology, UIUC (09/2017–12/2018)</p>
+    <ul>
+      <li>Automated 3D trait extraction via geometry processing on surface scans; mentored students in Python computer vision workflows.</li>
+    </ul>
+  </div>
+  <div class="experience-item">
+    <h3>Research Assistant</h3>
+    <p class="meta">Immunology and Genomics Lab, Department of Anthropology, UIUC (09/2016–05/2017)</p>
+    <ul>
+      <li>Quantified skeletal traits from micro-CT; authored an R package linking genotype–phenotype at scale.</li>
+    </ul>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- add dedicated Experience section with bullet highlights for four roles
- style experience cards with new CSS and link stylesheet
- insert "Experience" link in navbar after Home for quick access

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68aa33c27b24832787552a1e966a38f0